### PR TITLE
fix error with C-x v v (vc-next-action)

### DIFF
--- a/vc-osc.el
+++ b/vc-osc.el
@@ -259,7 +259,7 @@ to the OSC command."
   "Return non-nil if FILE could be registered in OSC.
 This is only possible if OSC is responsible for FILE's directory.")
 
-(defun vc-osc-checkin (files rev comment)
+(defun vc-osc-checkin (files comment rev)
   "OSC-specific version of `vc-backend-checkin'."
   (if rev (error "Committing to a specific revision is unsupported in OSC"))
   (let ((status (apply


### PR DESCRIPTION
vc-osc-checkin is called with (files comment rev)

At least in emacs 26... not sure if this is valid for other emacs versions.